### PR TITLE
LPS-44467 Avoid storing field _portletName since it is confusing (it's really storing the portlet id aka portletInstanceKey) and its value can be obtained from existing fields (such as _portlet)

### DIFF
--- a/git-commit-plugins
+++ b/git-commit-plugins
@@ -1,1 +1,1 @@
-dce7823727ffed5462ba1c7d9b1a51d34b53ddee
+https://github.com/juliocamarero/liferay-plugins/pull/153

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -237,6 +237,14 @@ public class PortletPreferencesLocalServiceImpl
 	}
 
 	@Override
+	public List<PortletPreferences> getPortletPreferencesByPortletInstanceKey(
+		String portletInstanceKey) {
+
+		return portletPreferencesPersistence.findByPortletId(
+			portletInstanceKey);
+	}
+
+	@Override
 	public long getPortletPreferencesCount(
 		int ownerType, long plid, String portletId) {
 

--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.xml.QName;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.PortletApp;
 import com.liferay.portal.model.PortletConstants;
+import com.liferay.portal.model.PortletInstance;
 import com.liferay.portal.model.PublicRenderParameter;
 import com.liferay.portal.model.User;
 import com.liferay.portal.security.lang.DoPrivilegedBean;
@@ -299,6 +300,10 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	public PortletContext getPortletContext() {
 		return _portletContext;
+	}
+
+	public PortletInstance getPortletInstance() {
+		return _portletInstance;
 	}
 
 	@Override
@@ -668,6 +673,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 		_portlet = portlet;
 		_portletName = portlet.getPortletId();
+		_portletInstance = PortletInstance.fromPortletInstanceKey(
+			portlet.getPortletId());
 
 		PortletApp portletApp = portlet.getPortletApp();
 
@@ -975,6 +982,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 	private PortalContext _portalContext;
 	private Portlet _portlet;
 	private PortletContext _portletContext;
+	private PortletInstance _portletInstance;
 	private PortletMode _portletMode;
 	private String _portletName;
 	private HttpServletRequest _portletRequestDispatcherRequest;

--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -750,33 +750,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		boolean windowStateRestoreCurrentView = ParamUtil.getBoolean(
 			request, "p_p_state_rcv");
 
-		PortletInstance currentPortletInstance =
-			PortletInstance.fromPortletInstanceKey(ppid);
-
-		String currentPortletInstancePortletName =
-			currentPortletInstance.getPortletName();
-
-		String currentPortletInstanceInstanceId =
-			currentPortletInstance.getInstanceId();
-
-		boolean samePortletInstance = false;
-
-		if (Validator.isNull(currentPortletInstanceInstanceId)) {
-			samePortletInstance = Validator.equals(_portletName, ppid);
-		}
-		else {
-			if (Validator.equals(
-					currentPortletInstancePortletName,
-					_portletInstance.getPortletName()) &&
-				Validator.equals(
-					currentPortletInstanceInstanceId,
-					_portletInstance.getInstanceId())) {
-
-				samePortletInstance = true;
-			}
-		}
-
-		if (samePortletInstance &&
+		if (isSamePortletInstance(ppid) &&
 			!(windowStateRestoreCurrentView &&
 			  portlet.isRestoreCurrentView())) {
 
@@ -924,6 +898,34 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 		_locale = themeDisplay.getLocale();
 		_plid = plid;
+	}
+
+	protected boolean isSamePortletInstance(String ppid) {
+		PortletInstance currentPortletInstance =
+			PortletInstance.fromPortletInstanceKey(ppid);
+
+		String currentPortletInstancePortletName =
+			currentPortletInstance.getPortletName();
+
+		String currentPortletInstanceInstanceId =
+			currentPortletInstance.getInstanceId();
+
+		if (Validator.isNull(currentPortletInstanceInstanceId)) {
+			return Validator.equals(_portletName, ppid);
+		}
+		else {
+			if (Validator.equals(
+					currentPortletInstancePortletName,
+					_portletInstance.getPortletName()) &&
+				Validator.equals(
+					currentPortletInstanceInstanceId,
+					_portletInstance.getInstanceId())) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	protected void mergePublicRenderParameters(

--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -332,7 +332,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		else {
 			if (create) {
 				_session = new PortletSessionImpl(
-					_req.getSession(), _portletContext, _portletName, _plid);
+					_req.getSession(), _portletContext, _portlet.getPortletId(), _plid);
 			}
 
 			return _ses;
@@ -342,7 +342,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			_req.getSession(create);
 
 			_session = new PortletSessionImpl(
-				_req.getSession(), _portletContext, _portletName, _plid);
+				_req.getSession(), _portletContext, _portlet.getPortletId(), _plid);
 		}*/
 
 		if (!create && _invalidSession) {
@@ -467,7 +467,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	@Override
 	public Map<String, String[]> getRenderParameters() {
-		return RenderParametersPool.get(_request, _plid, _portletName);
+		return RenderParametersPool.get(
+			_request, _plid, _portlet.getPortletId());
 	}
 
 	@Override
@@ -531,7 +532,9 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 
 	@Override
 	public String getWindowID() {
-		return _portletName.concat(
+		String portletName = _portlet.getPortletId();
+
+		return portletName.concat(
 			LiferayPortletSession.LAYOUT_SEPARATOR).concat(
 				String.valueOf(_plid));
 	}
@@ -673,7 +676,6 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			WebKeys.THEME_DISPLAY);
 
 		_portlet = portlet;
-		_portletName = portlet.getPortletId();
 		_portletInstance = PortletInstance.fromPortletInstanceKey(
 			portlet.getPortletId());
 
@@ -690,7 +692,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			}
 		}
 
-		String portletNamespace = PortalUtil.getPortletNamespace(_portletName);
+		String portletNamespace = PortalUtil.getPortletNamespace(
+			portlet.getPortletName());
 
 		boolean warFile = portletApp.isWARFile();
 
@@ -785,7 +788,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 				!LiferayWindowState.isPopUp(request)) {
 
 				RenderParametersPool.put(
-					request, plid, _portletName, renderParameters);
+					request, plid, _portlet.getPortletId(), renderParameters);
 			}
 
 			Map<String, String[]> parameters = request.getParameterMap();
@@ -830,7 +833,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		}
 		else {
 			Map<String, String[]> renderParameters = RenderParametersPool.get(
-				request, plid, _portletName);
+				request, plid, _portlet.getPortletId());
 
 			for (Map.Entry<String, String[]> entry :
 					renderParameters.entrySet()) {
@@ -860,7 +863,8 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		_portletMode = portletMode;
 		_preferences = preferences;
 		_session = new PortletSessionImpl(
-			_request.getSession(), _portletContext, _portletName, plid);
+			_request.getSession(), _portletContext, _portlet.getPortletId(),
+			plid);
 
 		String remoteUser = request.getRemoteUser();
 
@@ -912,7 +916,7 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 			currentPortletInstance.getInstanceId();
 
 		if (Validator.isNull(currentPortletInstanceInstanceId)) {
-			return Validator.equals(_portletName, ppid);
+			return Validator.equals(_portlet.getPortletId(), ppid);
 		}
 		else {
 			if (Validator.equals(
@@ -1013,7 +1017,6 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 	private PortletContext _portletContext;
 	private PortletInstance _portletInstance;
 	private PortletMode _portletMode;
-	private String _portletName;
 	private HttpServletRequest _portletRequestDispatcherRequest;
 	private PortletPreferences _preferences;
 	private Profile _profile;

--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -750,7 +750,33 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		boolean windowStateRestoreCurrentView = ParamUtil.getBoolean(
 			request, "p_p_state_rcv");
 
-		if (_portletName.equals(ppid) &&
+		PortletInstance currentPortletInstance =
+			PortletInstance.fromPortletInstanceKey(ppid);
+
+		String currentPortletInstancePortletName =
+			currentPortletInstance.getPortletName();
+
+		String currentPortletInstanceInstanceId =
+			currentPortletInstance.getInstanceId();
+
+		boolean samePortletInstance = false;
+
+		if (Validator.isNull(currentPortletInstanceInstanceId)) {
+			samePortletInstance = Validator.equals(_portletName, ppid);
+		}
+		else {
+			if (Validator.equals(
+					currentPortletInstancePortletName,
+					_portletInstance.getPortletName()) &&
+				Validator.equals(
+					currentPortletInstanceInstanceId,
+					_portletInstance.getInstanceId())) {
+
+				samePortletInstance = true;
+			}
+		}
+
+		if (samePortletInstance &&
 			!(windowStateRestoreCurrentView &&
 			  portlet.isRestoreCurrentView())) {
 

--- a/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletRequestImpl.java
@@ -311,9 +311,10 @@ public abstract class PortletRequestImpl implements LiferayPortletRequest {
 		return _portletMode;
 	}
 
+	@Deprecated
 	@Override
 	public String getPortletName() {
-		return _portletName;
+		return _portletInstance.getPortletInstanceKey();
 	}
 
 	@Override

--- a/portal-impl/test/integration/com/liferay/portlet/bundle/friendlyurlmappertrackerimpl/TestFriendlyURLMapper.java
+++ b/portal-impl/test/integration/com/liferay/portlet/bundle/friendlyurlmappertrackerimpl/TestFriendlyURLMapper.java
@@ -60,6 +60,11 @@ public class TestFriendlyURLMapper implements FriendlyURLMapper {
 	}
 
 	@Override
+	public boolean isCustomizablePortletInstance() {
+		return false;
+	}
+
+	@Override
 	public boolean isPortletInstanceable() {
 		return false;
 	}
@@ -68,6 +73,13 @@ public class TestFriendlyURLMapper implements FriendlyURLMapper {
 	public void populateParams(
 		String friendlyURLPath, Map<String, String[]> parameterMap,
 		Map<String, Object> requestContext) {
+
+		return;
+	}
+
+	@Override
+	public void setCustomizablePortletInstance(
+		boolean customizablePortletInstance) {
 
 		return;
 	}

--- a/portal-service/src/com/liferay/portal/kernel/portlet/BaseFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/BaseFriendlyURLMapper.java
@@ -58,8 +58,20 @@ public abstract class BaseFriendlyURLMapper implements FriendlyURLMapper {
 	}
 
 	@Override
+	public boolean isCustomizablePortletInstance() {
+		return _customizablePortletInstance;
+	}
+
+	@Override
 	public boolean isPortletInstanceable() {
 		return _portletInstanceable;
+	}
+
+	@Override
+	public void setCustomizablePortletInstance(
+		boolean customizablePortletInstance) {
+
+		_customizablePortletInstance = customizablePortletInstance;
 	}
 
 	@Override
@@ -260,6 +272,7 @@ public abstract class BaseFriendlyURLMapper implements FriendlyURLMapper {
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseFriendlyURLMapper.class);
 
+	private boolean _customizablePortletInstance;
 	private String _mapping;
 	private String _portletId;
 	private boolean _portletInstanceable;

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import javax.portlet.PortletMode;
 import javax.portlet.WindowState;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * The default friendly URL mapper to use with friendly URL routes.
  *
@@ -158,7 +160,12 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 
 		String namespace = null;
 
-		String portletId = getPortletId(routeParameters);
+		HttpServletRequest request = (HttpServletRequest)requestContext.get(
+			"request");
+
+		long userId = PortalUtil.getUserId(request);
+
+		String portletId = getPortletId(userId, routeParameters);
 
 		if (Validator.isNotNull(portletId)) {
 			namespace = PortalUtil.getPortletNamespace(portletId);
@@ -287,16 +294,19 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 	}
 
 	/**
-	 * Returns the portlet ID, including the instance ID if applicable, from the
-	 * parameter map.
+	 * Returns the portlet ID, including the instance ID and the user ID if
+	 * applicable, from the parameter map.
 	 *
+	 * @param  userId the primary key of the user
 	 * @param  routeParameters the parameter map. For an instanceable portlet,
 	 *         this must contain either <code>p_p_id</code> or
 	 *         <code>instanceId</code>.
 	 * @return the portlet ID, including the instance ID if applicable, or
 	 *         <code>null</code> if it cannot be determined
 	 */
-	protected String getPortletId(Map<String, String> routeParameters) {
+	protected String getPortletId(
+		long userId, Map<String, String> routeParameters) {
+
 		if (!isPortletInstanceable()) {
 			return getPortletId();
 		}

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -19,11 +19,15 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.PortletConstants;
+import com.liferay.portal.model.PortletInstance;
+import com.liferay.portal.model.PortletPreferences;
+import com.liferay.portal.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.util.PortalUtil;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -158,12 +162,16 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 			return;
 		}
 
-		String namespace = null;
-
 		HttpServletRequest request = (HttpServletRequest)requestContext.get(
 			"request");
 
 		long userId = PortalUtil.getUserId(request);
+
+		this.setCustomizablePortletInstance(
+			isCustomizablePortletInstanceFromPortletPreferences(
+				userId, routeParameters));
+
+		String namespace = null;
 
 		String portletId = getPortletId(userId, routeParameters);
 
@@ -350,6 +358,23 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 			FriendlyURLMapperThreadLocal.getPRPIdentifiers();
 
 		return routeParameterKeys.containsAll(publicRenderParameters.keySet());
+	}
+
+	protected boolean isCustomizablePortletInstanceFromPortletPreferences(
+		long userId, Map<String, String> routeParameters) {
+
+		String instanceId = routeParameters.get("instanceId");
+
+		PortletInstance portletInstance = new PortletInstance(
+			getPortletId(), userId, instanceId);
+
+		String portletInstanceKey = portletInstance.getPortletInstanceKey();
+
+		List<PortletPreferences> preferences =
+			PortletPreferencesLocalServiceUtil.
+				getPortletPreferencesByPortletInstanceKey(portletInstanceKey);
+
+		return (!preferences.isEmpty() && (preferences.size() == 1));
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -320,12 +320,25 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 		}
 
 		String portletId = routeParameters.remove("p_p_id");
+		String instanceId = routeParameters.remove("instanceId");
 
 		if (Validator.isNotNull(portletId)) {
+			if (isCustomizablePortletInstance()) {
+				if (userId > 0) {
+					return PortletConstants.assemblePortletId(
+						portletId, userId, instanceId);
+				}
+			}
+
 			return portletId;
 		}
 
-		String instanceId = routeParameters.remove("instanceId");
+		if (isCustomizablePortletInstance()) {
+			if (userId > 0) {
+				return PortletConstants.assemblePortletId(
+					getPortletId(), userId, instanceId);
+			}
+		}
 
 		if (Validator.isNotNull(instanceId)) {
 			return PortletConstants.assemblePortletId(

--- a/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/DefaultFriendlyURLMapper.java
@@ -360,6 +360,21 @@ public class DefaultFriendlyURLMapper extends BaseFriendlyURLMapper {
 		return routeParameterKeys.containsAll(publicRenderParameters.keySet());
 	}
 
+	/**
+	 * Returns <code>true</code> if a portlet preference exists in the database
+	 * for a portlet instance key. The portlet instance key is calculated using
+	 * the primary key of the portlet instance, the current user primary key and
+	 * the instanceId of the portlet.
+	 *
+	 * Only one portlet preference must exist on the database for a portlet
+	 * instance key, representing that the portlet instance has been deployed on
+	 * a customizable region of a layout by a user.
+	 *
+	 * @param userId the current user primary key
+	 * @param routeParameters the parameter map
+	 * @return <code>true</code> if a portlet preference exists in the database;
+	 *         <code>false</code> otherwise
+	 */
 	protected boolean isCustomizablePortletInstanceFromPortletPreferences(
 		long userId, Map<String, String> routeParameters) {
 

--- a/portal-service/src/com/liferay/portal/kernel/portlet/FriendlyURLMapper.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/FriendlyURLMapper.java
@@ -106,6 +106,16 @@ public interface FriendlyURLMapper {
 	public boolean isCheckMappingWithPrefix();
 
 	/**
+	 * Returns <code>true</code> if this portlet instance is deployed in a
+	 * customizable region of a layout.
+	 *
+	 * @return <code>true</code> if the portlet instance is deployed in a
+	 *         customizable region of a layout;
+	 *         <code>false</code> otherwise
+	 */
+	public boolean isCustomizablePortletInstance();
+
+	/**
 	 * Returns <code>true</code> if this portlet is instanceable.
 	 *
 	 * <p>
@@ -140,6 +150,16 @@ public interface FriendlyURLMapper {
 	public void populateParams(
 		String friendlyURLPath, Map<String, String[]> parameterMap,
 		Map<String, Object> requestContext);
+
+	/**
+	 * Sets whether this portlet instance is deployed in a customizable region
+	 * of a layout.
+	 *
+	 * @param customizablePortletInstance whether this portlet is deployed
+	 *                                    in a customizable region of a layout
+	 */
+	public void setCustomizablePortletInstance(
+		boolean customizablePortletInstance);
 
 	/**
 	 * Sets the friendly URL mapping for this portlet.

--- a/portal-service/src/com/liferay/portal/service/PortletPreferencesLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/PortletPreferencesLocalService.java
@@ -246,6 +246,10 @@ public interface PortletPreferencesLocalService extends BaseLocalService,
 		long plid);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.PortletPreferences> getPortletPreferencesByPortletInstanceKey(
+		java.lang.String portletInstanceKey);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public long getPortletPreferencesCount(long ownerId, int ownerType,
 		long plid, com.liferay.portal.model.Portlet portlet,
 		boolean excludeDefaultPreferences);

--- a/portal-service/src/com/liferay/portal/service/PortletPreferencesLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/PortletPreferencesLocalServiceUtil.java
@@ -296,6 +296,12 @@ public class PortletPreferencesLocalServiceUtil {
 		return getService().getPortletPreferencesByPlid(plid);
 	}
 
+	public static java.util.List<com.liferay.portal.model.PortletPreferences> getPortletPreferencesByPortletInstanceKey(
+		java.lang.String portletInstanceKey) {
+		return getService()
+				   .getPortletPreferencesByPortletInstanceKey(portletInstanceKey);
+	}
+
 	public static long getPortletPreferencesCount(long ownerId, int ownerType,
 		long plid, com.liferay.portal.model.Portlet portlet,
 		boolean excludeDefaultPreferences) {

--- a/portal-service/src/com/liferay/portal/service/PortletPreferencesLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/PortletPreferencesLocalServiceWrapper.java
@@ -322,6 +322,12 @@ public class PortletPreferencesLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<com.liferay.portal.model.PortletPreferences> getPortletPreferencesByPortletInstanceKey(
+		java.lang.String portletInstanceKey) {
+		return _portletPreferencesLocalService.getPortletPreferencesByPortletInstanceKey(portletInstanceKey);
+	}
+
+	@Override
 	public long getPortletPreferencesCount(long ownerId, int ownerType,
 		long plid, com.liferay.portal.model.Portlet portlet,
 		boolean excludeDefaultPreferences) {

--- a/util-bridges/src/com/liferay/util/bridges/wai/WAIFriendlyURLMapper.java
+++ b/util-bridges/src/com/liferay/util/bridges/wai/WAIFriendlyURLMapper.java
@@ -76,6 +76,11 @@ public class WAIFriendlyURLMapper implements FriendlyURLMapper {
 	}
 
 	@Override
+	public boolean isCustomizablePortletInstance() {
+		return false;
+	}
+
+	@Override
 	public boolean isPortletInstanceable() {
 		return false;
 	}
@@ -118,6 +123,11 @@ public class WAIFriendlyURLMapper implements FriendlyURLMapper {
 		String path = friendlyURLPath.substring(y);
 
 		parameterMap.put(namespace + "appURL", new String[] {path});
+	}
+
+	@Override
+	public void setCustomizablePortletInstance(
+		boolean customizablePortletInstance) {
 	}
 
 	@Override


### PR DESCRIPTION
This pull includes one commit of one change that I did myself