### PR TITLE
LPS-44701 PortletURLImpl changes internal state during serialization when copying current render parameters

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletURLImpl.java
@@ -1012,13 +1012,15 @@ public class PortletURLImpl
 			sb.append(StringPool.AMPERSAND);
 		}
 
+		Map<String, String[]> renderParams = _params;
+
 		if (_copyCurrentRenderParameters) {
-			mergeRenderParameters();
+			renderParams = _mergeWithRenderParameters(renderParams);
 		}
 
 		int previousSbIndex = sb.index();
 
-		for (Map.Entry<String, String[]> entry : _params.entrySet()) {
+		for (Map.Entry<String, String[]> entry : renderParams.entrySet()) {
 			String name = entry.getKey();
 			String[] values = entry.getValue();
 
@@ -1181,15 +1183,17 @@ public class PortletURLImpl
 			}
 		}
 
+		Map<String, String[]> renderParams = _params;
+
 		if (_copyCurrentRenderParameters) {
-			mergeRenderParameters();
+			renderParams = _mergeWithRenderParameters(renderParams);
 		}
 
 		StringBundler parameterSb = new StringBundler();
 
 		int previousSbIndex = sb.index();
 
-		for (Map.Entry<String, String[]> entry : _params.entrySet()) {
+		for (Map.Entry<String, String[]> entry : renderParams.entrySet()) {
 			String name = entry.getKey();
 			String[] values = entry.getValue();
 
@@ -1275,47 +1279,9 @@ public class PortletURLImpl
 		}
 	}
 
+	@Deprecated
 	protected void mergeRenderParameters() {
-		String namespace = getNamespace();
-
-		Layout layout = getLayout();
-
-		Map<String, String[]> renderParameters = RenderParametersPool.get(
-			_request, layout.getPlid(), getPortlet().getPortletId());
-
-		if (renderParameters == null) {
-			return;
-		}
-
-		for (Map.Entry<String, String[]> entry : renderParameters.entrySet()) {
-			String name = entry.getKey();
-
-			if (name.contains(namespace)) {
-				name = name.substring(namespace.length());
-			}
-
-			if (!_lifecycle.equals(PortletRequest.RESOURCE_PHASE) &&
-				(_removedParameterNames != null) &&
-				_removedParameterNames.contains(name)) {
-
-				continue;
-			}
-
-			String[] oldValues = entry.getValue();
-			String[] newValues = _params.get(name);
-
-			if (newValues == null) {
-				_params.put(name, oldValues);
-			}
-			else if (isBlankValue(newValues)) {
-				_params.remove(name);
-			}
-			else {
-				newValues = ArrayUtil.append(newValues, oldValues);
-
-				_params.put(name, newValues);
-			}
-		}
+		_params = _mergeWithRenderParameters(_params);
 	}
 
 	protected String prependNamespace(String name) {
@@ -1356,6 +1322,56 @@ public class PortletURLImpl
 		if (_params.containsKey(name)) {
 			_params.remove(name);
 		}
+	}
+
+	private Map<String, String[]> _mergeWithRenderParameters(
+		Map<String, String[]> portletURLParams) {
+
+		String namespace = getNamespace();
+
+		Layout layout = getLayout();
+
+		Map<String, String[]> renderParameters = RenderParametersPool.get(
+			_request, layout.getPlid(), getPortlet().getPortletId());
+
+		if (renderParameters == null) {
+			return portletURLParams;
+		}
+
+		Map<String, String[]> mergedRenderParams = new LinkedHashMap<>(
+			portletURLParams);
+
+		for (Map.Entry<String, String[]> entry : renderParameters.entrySet()) {
+			String name = entry.getKey();
+
+			if (name.contains(namespace)) {
+				name = name.substring(namespace.length());
+			}
+
+			if (!_lifecycle.equals(PortletRequest.RESOURCE_PHASE) &&
+				(_removedParameterNames != null) &&
+				_removedParameterNames.contains(name)) {
+
+				continue;
+			}
+
+			String[] oldValues = entry.getValue();
+			String[] newValues = _params.get(name);
+
+			if (newValues == null) {
+				mergedRenderParams.put(name, oldValues);
+			}
+			else if (isBlankValue(newValues)) {
+				mergedRenderParams.remove(name);
+			}
+			else {
+				newValues = ArrayUtil.append(newValues, oldValues);
+
+				mergedRenderParams.put(name, newValues);
+			}
+		}
+
+		return mergedRenderParams;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(PortletURLImpl.class);

--- a/portal-impl/test/integration/com/liferay/portlet/PortletURLImplTest.java
+++ b/portal-impl/test/integration/com/liferay/portlet/PortletURLImplTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.test.LayoutTestUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Manuel de la Peña
+ */
+public class PortletURLImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testToStringShouldNotReplicateExistingParamValues()
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		Layout layout = LayoutTestUtil.addLayout(_group);
+
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setLayout(layout);
+		themeDisplay.setPlid(layout.getPlid());
+		themeDisplay.setPortalURL("http://localhost:8080");
+
+		long plid = themeDisplay.getPlid();
+
+		Map<String, String[]> renderParameters = new HashMap<>();
+
+		String[] values = new String[] {"test1", "test2"};
+
+		renderParameters.put("test", values);
+
+		MockHttpServletRequest mockServletRequest =
+			new MockHttpServletRequest();
+
+		mockServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		RenderParametersPool.put(
+			mockServletRequest, plid, PortletKeys.LOGIN, renderParameters);
+
+		PortletURL portletURL = PortletURLFactoryUtil.create(
+			mockServletRequest, PortletKeys.LOGIN, plid, "RENDER_PHASE");
+
+		PortletURLImpl portletURLImpl = (PortletURLImpl)portletURL;
+
+		portletURLImpl.setCopyCurrentRenderParameters(true);
+
+		StringBuilder sb = new StringBuilder(10);
+
+		sb.append("http://localhost:8080/web");
+		sb.append(_group.getFriendlyURL());
+		sb.append(layout.getFriendlyURL());
+		sb.append("?p_p_id=");
+		sb.append(PortletKeys.LOGIN);
+		sb.append("&p_p_lifecycle=0&_");
+		sb.append(PortletKeys.LOGIN);
+		sb.append("_test=test1&_");
+		sb.append(PortletKeys.LOGIN);
+		sb.append("_test=test2");
+
+		Assert.assertEquals(sb.toString(), portletURL.toString());
+
+		portletURLImpl.clearCache();
+		Assert.assertEquals(sb.toString(), portletURL.toString());
+
+		portletURLImpl.clearCache();
+		Assert.assertEquals(sb.toString(), portletURL.toString());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-44701

Hi @mdelapenya,

thanks for the old PR. I changed the fix because your fix would discard same values if set multiple times (?fib=1&fib=1&fib=2).

I think this is safer.

However, I didn't manage to run tests, which are crucial in this PR. So waiting for our CI :)

Thanks!

Now hopefully with correct semver :)